### PR TITLE
[CDP-1842] Add support to communicate error message back to client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,4 @@ build:
 ## start: build and start local server
 .PHONY: start
 start: build
-	PORT=3000 AWS_DEFAULT_REGION=us-east-1 KINESIS_STREAM=my-stream java -jar target/app.jar
+	PORT=3000 AWS_DEFAULT_REGION=us-east-1 java -jar target/app.jar

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ your kinesis stream by setting the `AWS_DEFAULT_REGION` and `KINESIS_STREAM` env
 up and running, you can send data to Kinesis by opening a socket connection and sending utf-8 data. Each record you send
 should be delimited by a new line.
 
-Optionally, you can provide a host (`ERROR_SOCKET_HOST`) and port (`ERROR_SOCKET_PORT`) where any message which cannot
-be put in kinesis stream for any reason will be posted.
+Any message which cannot be put into kinesis stream for any reason will be sent to the client connected with port `3001`
+. This port can be overwritten by providing env var `ERROR_SOCKET_PORT`.
 
 ### docker image
 
@@ -25,9 +25,9 @@ This server is available as a docker image.
 ```sh
 docker run -it --rm \
   -p 3000:3000 \
+  -p 3001:3001 \
   -e AWS_DEFAULT_REGION=us-east-1 \
   -e KINESIS_STREAM=my-stream \
-  -e ERROR_SOCKET_HOST=127.0.0.1 \
   -e ERROR_SOCKET_PORT=3001 \
   quay.io/turner/kplserver
 ```
@@ -60,6 +60,11 @@ definition will configure this server as a sidecar container that you can talk t
           "protocol": "tcp",
           "hostPort": 3000,
           "containerPort": 3000
+        },
+        {
+          "protocol": "tcp",
+          "hostPort": 3001,
+          "containerPort": 3001
         }
       ],
       "environment": [
@@ -70,10 +75,6 @@ definition will configure this server as a sidecar container that you can talk t
         {
           "name": "PORT",
           "value": "3000"
-        },
-        {
-          "name": "ERROR_SOCKET_HOST",
-          "value": "127.0.0.1"
         },
         {
           "name": "ERROR_SOCKET_PORT",

--- a/README.md
+++ b/README.md
@@ -1,17 +1,22 @@
 # kplserver
 
-Exposes the [Amazon Kinesis Producer Library](https://github.com/awslabs/amazon-kinesis-producer) via sockets for multi-language support.
+Exposes the [Amazon Kinesis Producer Library](https://github.com/awslabs/amazon-kinesis-producer) via sockets for
+multi-language support.
 
 [![Docker Repository on Quay](https://quay.io/repository/turner/kplserver/status "Docker Repository on Quay")](https://quay.io/repository/turner/kplserver)
 
-The KPL is written in Java and designed to be consumed by Java applications.  This project may be useful if you're building a data ingestion app using Kinesis in a language other than Java.
+The KPL is written in Java and designed to be consumed by Java applications. This project may be useful if you're
+building a data ingestion app using Kinesis in a language other than Java.
 
 ### usage
 
-The server defaults to port `3000` but can be overridden by setting the `PORT` environment variable.  Point the server to your kinesis stream by setting the `AWS_DEFAULT_REGION` and `KINESIS_STREAM` environment variables.  Once the server is up and running, you can send data to Kinesis by opening a socket connection and sending utf-8 data.  Each record you send should be delimited by a new line. 
+The server defaults to port `3000` but can be overridden by setting the `PORT` environment variable. Point the server to
+your kinesis stream by setting the `AWS_DEFAULT_REGION` and `KINESIS_STREAM` environment variables. Once the server is
+up and running, you can send data to Kinesis by opening a socket connection and sending utf-8 data. Each record you send
+should be delimited by a new line.
 
-Optionally, you can provide an AWS SQS URL with env var `DLQ_URL` where any message which cannot be put in kinesis stream for any reason will be posted.
-
+Optionally, you can provide a host (`ERROR_SOCKET_HOST`) and port (`ERROR_SOCKET_PORT`) where any message which cannot
+be put in kinesis stream for any reason will be posted.
 
 ### docker image
 
@@ -22,13 +27,15 @@ docker run -it --rm \
   -p 3000:3000 \
   -e AWS_DEFAULT_REGION=us-east-1 \
   -e KINESIS_STREAM=my-stream \
-  -e DLQ_URL=my-sql-url \
+  -e ERROR_SOCKET_HOST=127.0.0.1 \
+  -e ERROR_SOCKET_PORT=3001 \
   quay.io/turner/kplserver
 ```
 
 ### sidecar
 
-If you're consuming the KPL from an ecs/fargate container, the followning container definitions snippet from a task definition will configure this server as a sidecar container that you can talk to over sockets via `127.0.0.1:3000`.
+If you're consuming the KPL from an ecs/fargate container, the followning container definitions snippet from a task
+definition will configure this server as a sidecar container that you can talk to over sockets via `127.0.0.1:3000`.
 
 <details><summary>task definition example</summary>
 
@@ -65,8 +72,12 @@ If you're consuming the KPL from an ecs/fargate container, the followning contai
           "value": "3000"
         },
         {
-          "name": "DLQ_URL",
-          "value": "https://sqs.us-east-1.amazonaws.com/651850529327/kinesis-dlq"
+          "name": "ERROR_SOCKET_HOST",
+          "value": "127.0.0.1"
+        },
+        {
+          "name": "ERROR_SOCKET_PORT",
+          "value": "3001"
         }
       ]
     }
@@ -76,11 +87,9 @@ If you're consuming the KPL from an ecs/fargate container, the followning contai
 
 </details>
 
-
 ### client libraries
 
 - [Go](https://github.com/turnerlabs/kplclientgo)
-
 
 ### development
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ The KPL is written in Java and designed to be consumed by Java applications.  Th
 
 ### usage
 
-The server defaults to port `3000` but can be overridden by setting the `PORT` environment variable.  Point the server to your kinesis stream by setting the `AWS_DEFAULT_REGION` and `KINESIS_STREAM` environment variables.  Once the server is up and running, you can send data to Kinesis by opening a socket connection and sending utf-8 data.  Each record you send should be delimited by a new line.
+The server defaults to port `3000` but can be overridden by setting the `PORT` environment variable.  Point the server to your kinesis stream by setting the `AWS_DEFAULT_REGION` and `KINESIS_STREAM` environment variables.  Once the server is up and running, you can send data to Kinesis by opening a socket connection and sending utf-8 data.  Each record you send should be delimited by a new line. 
+
+Optionally, you can provide an AWS SQS URL with env var `DLQ_URL` where any message which cannot be put in kinesis stream for any reason will be posted.
 
 
 ### docker image
@@ -20,6 +22,7 @@ docker run -it --rm \
   -p 3000:3000 \
   -e AWS_DEFAULT_REGION=us-east-1 \
   -e KINESIS_STREAM=my-stream \
+  -e DLQ_URL=my-sql-url \
   quay.io/turner/kplserver
 ```
 
@@ -60,6 +63,10 @@ If you're consuming the KPL from an ecs/fargate container, the followning contai
         {
           "name": "PORT",
           "value": "3000"
+        },
+        {
+          "name": "DLQ_URL",
+          "value": "https://sqs.us-east-1.amazonaws.com/651850529327/kinesis-dlq"
         }
       ]
     }

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.warnermedia</groupId>
   <artifactId>kplserver</artifactId>
@@ -21,6 +22,11 @@
       <groupId>com.amazonaws</groupId>
       <artifactId>amazon-kinesis-producer</artifactId>
       <version>0.14.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-sqs</artifactId>
+      <version>1.11.895</version>
     </dependency>
     <dependency>
       <groupId>javax.xml.bind</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,8 @@
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-sqs</artifactId>
-      <version>1.11.895</version>
+      <artifactId>aws-java-sdk</artifactId>
+      <version>1.11.327</version>
     </dependency>
     <dependency>
       <groupId>javax.xml.bind</groupId>

--- a/src/main/java/com/warnermedia/kplserver/App.java
+++ b/src/main/java/com/warnermedia/kplserver/App.java
@@ -21,11 +21,7 @@ public class App {
     BufferedReader in = new BufferedReader(new InputStreamReader(client.getInputStream()));
     String stream = getKinesisStream();
 
-    if (getErrSocketPort() != null) {
-      errSocket = new Socket(getErrSocketHost(), getErrSocketPort());
-    }
-
-    KinesisEventPublisher kinesisEventPublisher = new KinesisEventPublisher(stream, getRegion(), errSocket);
+    KinesisEventPublisher kinesisEventPublisher = new KinesisEventPublisher(stream, getRegion(), getErrSocketPort(), getErrSocketHost());
 
     // graceful shutdowns
     Runtime.getRuntime().addShutdownHook(new Thread() {
@@ -76,11 +72,13 @@ public class App {
     String p = System.getenv("ERROR_SOCKET_PORT");
     try {
       return Integer.parseInt(p);
-    } catch (Exception e) {
-      System.out.println("No port sat for errors");
+    } catch (
+      Exception e) {
+      System.out.println("There is no or invalid port set for errors");
       System.out.println(e);
       return null;
     }
+
   }
 
   static String getKinesisStream() {

--- a/src/main/java/com/warnermedia/kplserver/App.java
+++ b/src/main/java/com/warnermedia/kplserver/App.java
@@ -67,8 +67,4 @@ public class App {
   static String getRegion() {
     return System.getenv("AWS_DEFAULT_REGION");
   }
-
-  static String getDlqUrl() {
-    return System.getenv("DLQ_URL");
-  }
 }

--- a/src/main/java/com/warnermedia/kplserver/App.java
+++ b/src/main/java/com/warnermedia/kplserver/App.java
@@ -1,24 +1,25 @@
 package com.warnermedia.kplserver;
 
-import java.io.*;
-import java.net.ServerSocket;
-import java.net.Socket;
-import java.nio.ByteBuffer;
-import java.math.BigInteger;
-import java.util.Random;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ExecutorService;
-
-import com.amazonaws.services.kinesis.producer.UserRecordFailedException;
-import com.amazonaws.services.kinesis.producer.UserRecordResult;
+import com.amazonaws.services.kinesis.producer.Attempt;
 import com.amazonaws.services.kinesis.producer.KinesisProducer;
 import com.amazonaws.services.kinesis.producer.KinesisProducerConfiguration;
 import com.amazonaws.services.kinesis.producer.UserRecord;
-import com.amazonaws.services.kinesis.producer.Attempt;
-
+import com.amazonaws.services.kinesis.producer.UserRecordFailedException;
+import com.amazonaws.services.kinesis.producer.UserRecordResult;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.math.BigInteger;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.ByteBuffer;
+import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 public class App {
 
@@ -35,11 +36,11 @@ public class App {
           Attempt last = ((UserRecordFailedException) t).getResult().getAttempts().get(attempts);
           if (attempts > 1) {
             Attempt previous = ((UserRecordFailedException) t).getResult().getAttempts().get(attempts - 1);
-            System.out.println(String.format("Record failed to put - %s : %s. Previous failure - %s : %s",
-                last.getErrorCode(), last.getErrorMessage(), previous.getErrorCode(), previous.getErrorMessage()));
+            System.out.printf("Record failed to put - %s : %s. Previous failure - %s : %s%n",
+              last.getErrorCode(), last.getErrorMessage(), previous.getErrorCode(), previous.getErrorMessage());
           } else {
             System.out
-                .println(String.format("Record failed to put - %s : %s.", last.getErrorCode(), last.getErrorMessage()));
+              .printf("Record failed to put - %s : %s.%n", last.getErrorCode(), last.getErrorMessage());
           }
         }
       }
@@ -73,7 +74,7 @@ public class App {
     System.out.println("connection from " + clientAddress);
 
     BufferedReader in = new BufferedReader(new InputStreamReader(client.getInputStream()));
-    String line = null;
+    String line;
     String stream = getKinesisStream();
 
     KinesisProducerConfiguration config = new KinesisProducerConfiguration().setRegion(getRegion());
@@ -87,7 +88,7 @@ public class App {
         line += "\n";
 
         // write to kinesis
-        ByteBuffer data = ByteBuffer.wrap(line.getBytes("UTF-8"));
+        ByteBuffer data = ByteBuffer.wrap(line.getBytes(java.nio.charset.StandardCharsets.UTF_8));
         UserRecord userRecord = new UserRecord(stream, " ", randomExplicitHashKey(), data);
         try {
           ListenableFuture<UserRecordResult> f = producer.addUserRecord(userRecord);

--- a/src/main/java/com/warnermedia/kplserver/App.java
+++ b/src/main/java/com/warnermedia/kplserver/App.java
@@ -63,7 +63,7 @@ public class App {
   static String getErrSocketHost() {
     String h = System.getenv("ERROR_SOCKET_HOST");
     if (h == null || h.equals("")) {
-      return "127.0.01";
+      return "127.0.0.1";
     }
     return h;
   }

--- a/src/main/java/com/warnermedia/kplserver/KinesisEventPublisher.java
+++ b/src/main/java/com/warnermedia/kplserver/KinesisEventPublisher.java
@@ -70,8 +70,8 @@ public class KinesisEventPublisher {
             if (errSocket != null && (errClient == null || !errClient.isConnected())) {
               errClient = errSocket.accept();
               errClient.setKeepAlive(true);
+              errOutputStream = new DataOutputStream((errClient.getOutputStream()));
               System.out.println("error socket connection from " + errClient.getInetAddress().getHostAddress());
-              return;
             }
           } catch (Exception e) {
             log.error(String.format(
@@ -101,9 +101,11 @@ public class KinesisEventPublisher {
 
           if (errOutputStream != null) {
             try {
-              errOutputStream.writeUTF(finalLine);
+              errOutputStream.writeBytes(finalLine);
               errOutputStream.flush();
+              log.info("Sent the record to output stream");
             } catch (IOException ioException) {
+              System.out.println("Unable to send data to err channel");
               ioException.printStackTrace();
             }
           }

--- a/src/main/java/com/warnermedia/kplserver/KinesisEventPublisher.java
+++ b/src/main/java/com/warnermedia/kplserver/KinesisEventPublisher.java
@@ -29,6 +29,7 @@ public class KinesisEventPublisher {
   final ExecutorService callbackThreadPool = Executors.newCachedThreadPool();
   private final AmazonSQS sqs;
   private final KinesisProducer kinesis;
+  private static final String queueUrl = System.getenv("DLQ_URL");
 
   public KinesisEventPublisher(String stream, String region) {
     this.stream = stream;
@@ -82,7 +83,6 @@ public class KinesisEventPublisher {
             "Record failed to put payload=%s, attempts:%s",
             finalLine, errorList));
 
-          String queueUrl = System.getenv("DLQ_URL");
           if (queueUrl != null) {
             SendMessageRequest send_msg_request = new SendMessageRequest()
               .withQueueUrl(queueUrl)

--- a/src/main/java/com/warnermedia/kplserver/SendEventsToKinesis.java
+++ b/src/main/java/com/warnermedia/kplserver/SendEventsToKinesis.java
@@ -1,0 +1,2 @@
+package com.warnermedia.kplserver;public class SendEventsToKinesis {
+}

--- a/src/main/java/com/warnermedia/kplserver/SendEventsToKinesis.java
+++ b/src/main/java/com/warnermedia/kplserver/SendEventsToKinesis.java
@@ -1,2 +1,97 @@
-package com.warnermedia.kplserver;public class SendEventsToKinesis {
+package com.warnermedia.kplserver;
+
+import com.amazonaws.services.kinesis.producer.KinesisProducer;
+import com.amazonaws.services.kinesis.producer.KinesisProducerConfiguration;
+import com.amazonaws.services.kinesis.producer.UserRecord;
+import com.amazonaws.services.kinesis.producer.UserRecordFailedException;
+import com.amazonaws.services.kinesis.producer.UserRecordResult;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.io.BufferedReader;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+public class SendEventsToKinesis {
+  private final BufferedReader inputQueue;
+  private final String stream;
+  private static final Log log = LogFactory.getLog(
+    SendEventsToKinesis.class);
+
+  private final KinesisProducer kinesis;
+
+  public SendEventsToKinesis(String stream, String region, BufferedReader inputQueue) {
+    this.inputQueue = inputQueue;
+    this.stream = stream;
+    kinesis = new KinesisProducer(new KinesisProducerConfiguration()
+      .setRegion(region));
+  }
+
+  public void runOnce() throws Exception {
+    String line = inputQueue.readLine();
+    if (line == null) {
+      return;
+    }
+
+    // add new line so that downstream systems have an easier time parsing
+    String finalLine = line + "\n";
+
+    ByteBuffer data = ByteBuffer.wrap(line.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+    while (kinesis.getOutstandingRecordsCount() > 1e4) {
+      log.info("Too many outstanding records pending in the queue. Waiting for a second.");
+      Thread.sleep(1000);
+    }
+
+    UserRecord userRecord = new UserRecord(stream, " ", randomExplicitHashKey(), data);
+    ListenableFuture<UserRecordResult> f = kinesis.addUserRecord(userRecord);
+
+
+    Futures.addCallback(f, new FutureCallback<UserRecordResult>() {
+
+      @Override
+      public void onSuccess(UserRecordResult result) {
+        // noop
+      }
+
+      @Override
+      public void onFailure(Throwable t) {
+        if (t instanceof UserRecordFailedException) {
+          UserRecordFailedException e =
+            (UserRecordFailedException) t;
+          UserRecordResult result = e.getResult();
+
+          String errorList =
+            StringUtils.join(result.getAttempts().stream()
+              .map(a -> String.format(
+                "Delay after prev attempt: %d ms, "
+                  + "Duration: %d ms, Code: %s, "
+                  + "Message: %s",
+                a.getDelay(), a.getDuration(),
+                a.getErrorCode(),
+                a.getErrorMessage()))
+              .collect(Collectors.toList()), "n");
+
+          log.error(String.format(
+            "Record failed to put, partitionKey=%s, "
+              + "payload=%s, attempts:n%s",
+            " ", finalLine, errorList));
+        }
+      }
+    });
+  }
+
+  private String randomExplicitHashKey() {
+    return new BigInteger(128, new Random()).toString(10);
+  }
+
+  public void stop() {
+    kinesis.flushSync();
+    kinesis.destroy();
+  }
 }


### PR DESCRIPTION
[CDP-1842](https://jiraprod.turner.com/browse/CDP-1842)

This PR add an optional DLQ SQS support  if message cannot be put in kinesis for any reason.

## Test:

Tested with kplclientgo.

### Positive scenario
Command: AWS_PROFILE=xxxxxxxx KINESIS_STREAM=test DLQ_URL=https://sqs.us-east-1.amazonaws.com/651850529327/kinesis-dlq go test -v

Able to see the message in AWS cloudwatch:

![image](https://user-images.githubusercontent.com/61883345/98698185-c207bc80-2343-11eb-9d36-c82f5336289b.png)


### Negative Scenario (Configure with non existent stream test1)
 AWS_PROFILE=xxxxxxxxx KINESIS_STREAM=test1 DLQ_URL=https://sqs.us-east-1.amazonaws.com/651850529327/kinesis-dlq go test -v

**Error Log:** 

Nov 10, 2020 4:10:07 PM com.amazonaws.services.kinesis.producer.LogInputStreamReader$6 apply
kplserver_1  | SEVERE: [2020-11-10 16:10:07.553583] [0x00000019][0x00007f7d6e5c8700] [error] [AWS Log: ERROR](AWSClient)HTTP response code: 400
kplserver_1  | Exception name: ResourceNotFoundException
kplserver_1  | Error message: Stream test1 under account 651850529327 not found.
kplserver_1  | 6 response headers:
kplserver_1  | connection : close
kplserver_1  | content-length : 101
kplserver_1  | content-type : application/x-amz-json-1.1
kplserver_1  | date : Tue, 10 Nov 2020 16:10:07 GMT
kplserver_1  | x-amz-id-2 : 5194IxZKlrssyBnalqda3sbTS3yGbrx0t4J9I0cDtxiWbEqTGYjDQLQAYDIGF9EbW8uUlBsskP7Y6WevfRxVofbPV8cv7Afm
kplserver_1  | x-amzn-requestid : e58088a1-3485-39b0-bda4-353eb64b393b

Message is found in the SQS:

![image](https://user-images.githubusercontent.com/61883345/98700430-2a579d80-2346-11eb-9c96-e5039d8ad2ce.png)




